### PR TITLE
Fix for cursor getting stuck invisible

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For use on Wayland, since `unclutter`, `unclutter-xfixes` and `xbanish` only wor
 
 (Or download the file `hide-cursor@elcste.com.zip` from a [release](https://github.com/elcste/hide-cursor/releases) and run `gnome-extensions install hide-cursor@elcste.com.zip`)
 
-The latest version (3.1.1) supports GNOME Shell (GS) 49 and 50. Much thanks to a contributor: this extension has been essentially rewritten. The timeout value is now followed correctly and this value is configurable with a setting.
+The latest version (3.2.0) supports GNOME Shell (GS) 49 and 50. Much thanks to a contributor: this extension has been essentially rewritten. The timeout value is now followed correctly and this value is configurable with a setting.
 
 Settings are translated to Dutch, German and Russian, thanks to contributors.
 

--- a/extension.js
+++ b/extension.js
@@ -69,13 +69,13 @@ export default class HideCursor extends Extension {
   move = () => {
     this._lastMove = Date.now()
 
+    if (!this._tracker.get_pointer_visible())
+      this._tracker.uninhibit_cursor_visibility()
+
     if (this._hasFocusInhibited) {
       this._seat.uninhibit_unfocus()
       this._hasFocusInhibited = false
     }
-
-    if (!this._tracker.get_pointer_visible())
-      this._tracker.uninhibit_cursor_visibility()
 
     this._hasVisibilityInhibited = false
   }


### PR DESCRIPTION
When the cursor is hidden, selecting text or dragging a scrollbar causes it to get stuck invisible. Reverse the execution order inside move() to restore cursor visibility before releasing the focus lock. (h/t aves84)

Closes https://github.com/elcste/hide-cursor/issues/21.